### PR TITLE
Add refresh capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Mock server powered by scenarios.
   - [Running tests in parallel](#running-tests-in-parallel)
     - [sms-scenario-id header](#sms-scenario-id-header)
     - [sms-context-id header](#sms-context-id-header)
+	- [Reloading scenarios](#reloading-scenarios)
+		- [path](#path)
+		- [fn](#fn)
   - [Additional API paths](#additional-api-paths)
     - [/scenarios](#scenarios)
     - [/select-scenario](#select-scenario)
@@ -126,6 +129,34 @@ When this header is set to the scenario id of choice, regardless of what the cur
 
 This header must also be set when context is being used, otherwise context will reset on each call to the server when using the `sms-scenario-id` header.
 
+## Reloading scenarios
+
+To help active development while the mock server is running, the mock server can be loaded with a new set of scenarios, allowing you to make changes to your mock files and re-load them into the scenario mock server without needing a full restart of the mock server. This works by calling the `refresh.fn` when the `refresh.path` is POSTed to, expecting the `refresh.fn` to return a scenario map to be loaded into the scenario mock server. To configure this behaviour, during initialisation of the scenario-mock-server a refresh object can be passed into the options that takes 2 properties:
+
+### `path`
+
+You can optionally provide a `refresh.path` as a string that determines what path you can POST to to trigger a refresh. This defaults to `/refresh`.
+
+### `fn`
+
+Passing a function to `refresh.fn` will cause it to be called when the refresh path is POSTed to. The return value of the function will then be used as the new scenario map. For example:
+
+```javascript
+const getNewScenarios = () => {
+	return newScenarioMap;
+};
+
+run({
+	scenarios,
+	options: {
+		refresh: {
+			path: '/refresh',
+			fn: getNewScenarios,
+		},
+	},
+});
+```
+
 ## Additional API paths
 
 In addition to responding to API requests as set up by the currently active scenario a few additional endpoints exist that return json:
@@ -134,7 +165,7 @@ In addition to responding to API requests as set up by the currently active scen
 - `/select-scenario`
 - `/groups`
 
-These paths can be modified by using `options` (in case they clash with paths from scnearios).
+These paths can be modified by using `options` (in case they clash with paths from scenarios).
 
 ### /scenarios
 
@@ -215,19 +246,21 @@ Returns an http server, with an additional kill method.
 
 #### options
 
-> `{ port, uiPath, selectScenarioPath, scenariosPath, groupsPath, cookieMode, parallelContextSize }` | defaults to `{}`
+> `{ port, uiPath, selectScenarioPath, scenariosPath, groupsPath, cookieMode, parallelContextSize, refresh }` | defaults to `{}`
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
-| Property            | Type      | Default            | Description                                                                                                                    |
-| ------------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| port                | `number`  | `3000`             | Port that the http server runs on.                                                                                             |
-| uiPath              | `string`  | `/`                | Path that the UI will load on. `http://localhost:{port}{uiPath}`                                                               |
-| selectScenarioPath  | `string`  | `/select-scenario` | API path for selecting a scenario. `http://localhost:{port}{selectScenarioPath}`                                               |
-| scenariosPath       | `string`  | `/scenarios`       | API path for getting scenarios. `http://localhost:{port}{scenariosPath}`                                                       |
-| groupsPath          | `string`  | `/groups`          | API path for getting groups. `http://localhost:{port}{groupsPath}`                                                             |
-| cookieMode          | `boolean` | `false`            | Whether or not to store scenario selections in a cookie rather than directly in the server                                     |
-| parallelContextSize | `number`  | `10`               | How large to make the number of contexts that can run in parallel. See [Running tests in parallel](#running-tests-in-parallel) |
+| Property            | Type      | Default             | Description                                                                                                                    |
+| ------------------- | --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| port                | `number`  | `3000`              | Port that the http server runs on.                                                                                             |
+| uiPath              | `string`  | `/`                 | Path that the UI will load on. `http://localhost:{port}{uiPath}`                                                               |
+| selectScenarioPath  | `string`  | `/select-scenario`  | API path for selecting a scenario. `http://localhost:{port}{selectScenarioPath}`                                               |
+| scenariosPath       | `string`  | `/scenarios`        | API path for getting scenarios. `http://localhost:{port}{scenariosPath}`                                                       |
+| groupsPath          | `string`  | `/groups`           | API path for getting groups. `http://localhost:{port}{groupsPath}`                                                             |
+| cookieMode          | `boolean` | `false`             | Whether or not to store scenario selections in a cookie rather than directly in the server                                     |
+| parallelContextSize | `number`  | `10`                | How large to make the number of contexts that can run in parallel. See [Running tests in parallel](#running-tests-in-parallel) |
+| refresh.path        | `string`  | `/refresh`          | API path for re-loading scenarios. See [Reloading scenarios](#reloading-scenarios)              															 |
+| refresh.fn          | `number`  | `() => scenarioMap` | Function for to specify what scenarios to reload. See [Reloading scenarios](#reloading-scenarios) 														 |
 
 ## Types
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,192 +1,232 @@
 import { run } from '../src';
+import { ScenarioMap } from '../src/types';
+
+const scenarios: ScenarioMap = {
+	default: {
+		description: 'Default set of mocks',
+		context: {
+			a: 1,
+			b: 2,
+			c: 3,
+		},
+		mocks: [
+			{
+				path: '/api/test-me',
+				method: 'GET',
+				response: { data: { blue: 'yoyo' } },
+			},
+			{
+				path: '/api/return/:someId',
+				method: 'GET',
+				response: ({ query, params }) => {
+					return {
+						data: {
+							query,
+							params,
+						},
+					};
+				},
+			},
+			{
+				path: '/api/return/:someId',
+				method: 'POST',
+				response: async ({ body, params }) => {
+					return {
+						data: {
+							body,
+							params,
+						},
+					};
+				},
+			},
+			{
+				path: '/api/graphql',
+				method: 'GRAPHQL',
+				operations: [
+					{
+						type: 'query',
+						name: 'Cheese',
+						response: {
+							data: {
+								data: {
+									name: 'Cheddar',
+								},
+							},
+						},
+					},
+					{
+						type: 'query',
+						name: 'Bread',
+						response: {
+							data: {
+								data: {
+									name: 'Bread Roll',
+								},
+							},
+						},
+					},
+				],
+			},
+			{
+				path: '/api/graphql-function',
+				method: 'GRAPHQL',
+				operations: [
+					{
+						type: 'query',
+						name: 'Function',
+						response: async ({ variables }) => {
+							return {
+								data: {
+									data: {
+										variables,
+									},
+								},
+							};
+						},
+					},
+				],
+			},
+			{
+				path: '/api/context',
+				method: 'GET',
+				response: ({ context }) => ({ data: context }),
+			},
+			{
+				path: '/api/context',
+				method: 'PUT',
+				response: ({ body, updateContext }) => ({
+					data: updateContext(body),
+				}),
+			},
+		],
+	},
+	blueCheese: {
+		name: 'Blue cheese',
+		group: 'cheese',
+		mocks: [
+			{
+				path: '/api/test-me',
+				method: 'GET',
+				response: { data: { blue: 'cheese' } },
+			},
+			{
+				path: '/api/graphql',
+				method: 'GRAPHQL',
+				operations: [
+					{
+						type: 'query',
+						name: 'Cheese',
+						response: {
+							data: {
+								data: {
+									name: 'Blue Cheese',
+								},
+							},
+						},
+					},
+				],
+			},
+		],
+	},
+	redCheese: {
+		name: 'Red cheese',
+		group: 'cheese',
+		mocks: [
+			{
+				path: '/api/test-me',
+				method: 'GET',
+				response: { data: { red: 'leicester' } },
+			},
+			{
+				path: '/api/graphql',
+				method: 'GRAPHQL',
+				operations: [
+					{
+						type: 'query',
+						name: 'Cheese',
+						response: {
+							data: {
+								data: {
+									name: 'Red Leicester',
+								},
+							},
+						},
+					},
+				],
+			},
+		],
+	},
+	tigerBread: {
+		name: 'Tiger bread',
+		group: 'bread',
+		extend: 'default',
+		mocks: [],
+	},
+	baguette: {
+		name: 'Baguette',
+		group: 'bread',
+		extend: 'default',
+		mocks: [],
+	},
+	fish: {
+		name: 'Fish',
+		extend: 'default',
+		mocks: [
+			{
+				path: '/api/test-me-2',
+				method: 'GET',
+				response: { data: { blue: 'tang' } },
+			},
+		],
+	},
+	water: {
+		name: 'Water',
+		extend: 'default',
+		mocks: [],
+	},
+};
+const scenariosPostRefresh: ScenarioMap = {
+	default: {
+		description: 'Default set of mocks 2',
+		context: {
+			a: 1,
+			b: 2,
+			c: 3,
+		},
+		mocks: [
+			{
+				path: '/api/test-me',
+				method: 'GET',
+				response: { data: { blue: 'test 2!' } },
+			},
+			{
+				path: '/api/return/:someId',
+				method: 'GET',
+				response: ({ query, params }) => {
+					return {
+						data: {
+							query,
+							params,
+						},
+					};
+				},
+			},
+		],
+	},
+};
 
 run({
-	scenarios: {
-		default: {
-			description: 'Default set of mocks',
-			context: {
-				a: 1,
-				b: 2,
-				c: 3,
-			},
-			mocks: [
-				{
-					path: '/api/test-me',
-					method: 'GET',
-					response: { data: { blue: 'yoyo' } },
-				},
-				{
-					path: '/api/return/:someId',
-					method: 'GET',
-					response: ({ query, params }) => {
-						return {
-							data: {
-								query,
-								params,
-							},
-						};
-					},
-				},
-				{
-					path: '/api/return/:someId',
-					method: 'POST',
-					response: async ({ body, params }) => {
-						return {
-							data: {
-								body,
-								params,
-							},
-						};
-					},
-				},
-				{
-					path: '/api/graphql',
-					method: 'GRAPHQL',
-					operations: [
-						{
-							type: 'query',
-							name: 'Cheese',
-							response: {
-								data: {
-									data: {
-										name: 'Cheddar',
-									},
-								},
-							},
-						},
-						{
-							type: 'query',
-							name: 'Bread',
-							response: {
-								data: {
-									data: {
-										name: 'Bread Roll',
-									},
-								},
-							},
-						},
-					],
-				},
-				{
-					path: '/api/graphql-function',
-					method: 'GRAPHQL',
-					operations: [
-						{
-							type: 'query',
-							name: 'Function',
-							response: async ({ variables }) => {
-								return {
-									data: {
-										data: {
-											variables,
-										},
-									},
-								};
-							},
-						},
-					],
-				},
-				{
-					path: '/api/context',
-					method: 'GET',
-					response: ({ context }) => ({ data: context }),
-				},
-				{
-					path: '/api/context',
-					method: 'PUT',
-					response: ({ body, updateContext }) => ({
-						data: updateContext(body),
-					}),
-				},
-			],
-		},
-		blueCheese: {
-			name: 'Blue cheese',
-			group: 'cheese',
-			mocks: [
-				{
-					path: '/api/test-me',
-					method: 'GET',
-					response: { data: { blue: 'cheese' } },
-				},
-				{
-					path: '/api/graphql',
-					method: 'GRAPHQL',
-					operations: [
-						{
-							type: 'query',
-							name: 'Cheese',
-							response: {
-								data: {
-									data: {
-										name: 'Blue Cheese',
-									},
-								},
-							},
-						},
-					],
-				},
-			],
-		},
-		redCheese: {
-			name: 'Red cheese',
-			group: 'cheese',
-			mocks: [
-				{
-					path: '/api/test-me',
-					method: 'GET',
-					response: { data: { red: 'leicester' } },
-				},
-				{
-					path: '/api/graphql',
-					method: 'GRAPHQL',
-					operations: [
-						{
-							type: 'query',
-							name: 'Cheese',
-							response: {
-								data: {
-									data: {
-										name: 'Red Leicester',
-									},
-								},
-							},
-						},
-					],
-				},
-			],
-		},
-		tigerBread: {
-			name: 'Tiger bread',
-			group: 'bread',
-			extend: 'default',
-			mocks: [],
-		},
-		baguette: {
-			name: 'Baguette',
-			group: 'bread',
-			extend: 'default',
-			mocks: [],
-		},
-		fish: {
-			name: 'Fish',
-			extend: 'default',
-			mocks: [
-				{
-					path: '/api/test-me-2',
-					method: 'GET',
-					response: { data: { blue: 'tang' } },
-				},
-			],
-		},
-		water: {
-			name: 'Water',
-			extend: 'default',
-			mocks: [],
-		},
-	},
+	scenarios,
 	groups: {
 		bread: 'Bread',
 		cheese: 'Cheese',
+	},
+	options: {
+		refresh: {
+			path: '/refresh',
+			fn: () => {
+				return scenariosPostRefresh;
+			},
+		},
 	},
 });

--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -7,11 +7,13 @@ function Html({
 	uiPath,
 	scenarios,
 	groups,
+	refreshPath,
 }: {
 	uiPath: string;
 	scenarios: Array<ApiScenario>;
 	groups: Record<string, string>;
 	updatedScenarioName?: string;
+	refreshPath?: string;
 }) {
 	return (
 		<html lang="en">
@@ -26,6 +28,22 @@ function Html({
 					rel="stylesheet"
 					href={`${uiPath}${uiPath.slice(-1) === '/' ? '' : '/'}index.css`}
 				/>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `
+function refresh() {
+	const xhr = new XMLHttpRequest();
+	xhr.open('POST', '${refreshPath}', true);
+	xhr.setRequestHeader('Content-Type', 'application/json');
+	xhr.send();
+	location.reload();
+}
+window.addEventListener('load', function() {
+	document.getElementById("refresh-button").addEventListener("click", refresh);
+});
+						`,
+					}}
+				/>
 			</head>
 			<body>
 				<main>
@@ -35,6 +53,9 @@ function Html({
 							<a href={uiPath}>Refresh page</a>
 						</p>
 						<CallToActionButton />
+						<button id="refresh-button" type="button">
+							Reload Scenarios
+						</button>
 						<fieldset className="stack-3">
 							<legend>
 								<h1>Scenarios</h1>

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -107,6 +107,11 @@ button {
 	color: white;
 	padding: 0.5rem 1rem;
 	border-radius: 5px;
+	cursor: pointer;
+}
+
+button + button {
+	margin-left: 1rem;
 }
 
 button:focus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,10 @@ export type Options = {
 	groupsPath?: string;
 	cookieMode?: boolean;
 	parallelContextSize?: number;
+	refresh?: {
+		path?: string;
+		fn?(): ScenarioMap;
+	};
 };
 
 export type Context = Record<string, unknown>;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -18,6 +18,7 @@ export { getUi, updateUi };
 
 function getUi({
 	uiPath,
+	refreshPath,
 	cookieMode,
 	scenarios,
 	initialScenarioId,
@@ -28,6 +29,7 @@ function getUi({
 	groups,
 }: {
 	uiPath: string;
+	refreshPath: string;
 	cookieMode: boolean;
 	scenarios: InternalScenario[];
 	initialScenarioId: string;
@@ -48,7 +50,12 @@ function getUi({
 	});
 
 	const html = renderToStaticMarkup(
-		<Html uiPath={uiPath} scenarios={data} groups={groups} />,
+		<Html
+			uiPath={uiPath}
+			scenarios={data}
+			groups={groups}
+			refreshPath={refreshPath}
+		/>,
 	);
 
 	return '<!DOCTYPE html>\n' + html;


### PR DESCRIPTION
Adds refresh capability to the mock server via an additional option, and a button on the UI that triggers the re-loading of mocks. Function is primarily for development purposes, when changing/adding mocks.

Changed 'scenario' storage to use variables within the `express.ts` file to facilitate this functionality - refresh rewrites this value, and this value is the one used for mock matching later on.